### PR TITLE
Fixed ODT export.

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -99,7 +99,8 @@ class syntax_plugin_sortablejs extends DokuWiki_Syntax_Plugin {
           }
           break;
         case DOKU_LEXER_EXIT :
-          $renderer->p_open(); // re-open the paragraph
+          //$renderer->p_open();
+          // DO NOT re-open the paragraph, it would cause an error if the table is the last content on a page
           break;
       }
       return true;


### PR DESCRIPTION
The paragraph should not be re-opend. The old code only worked if after the table some other content was present. If the table was the last content on a page, then a paragraph open tag was not closed properly in the ODT XML code. The decission when to open a new pharagraph is up to the ODT export plugin, let it take care of it.
