### PR TITLE
fix sort order for non-english languages

### DIFF
--- a/script.js
+++ b/script.js
@@ -597,9 +597,7 @@ sorttable = {
     return aa-bb;
   },
   sort_alpha: function(a,b) {
-    if (a[0]==b[0]) {return 0;}
-    if (a[0]<b[0]) {return -1;}
-    return 1;
+    sorttable.sort_alpha = function(a,b) { return a[0].localeCompare(b[0]); 
   },
   sort_ddmm: function(a,b) {
     mtch = a[0].match(sorttable.DATE_RE);


### PR DESCRIPTION
Fixed sort order for non-english languages, see: http://www.kryogenix.org/code/browser/sorttable/#notenglish

German umlauts are sorted correctly and the sort is case insensitive now.