### PR TITLE
Suppress Header Arrows for "nosort" - Simple Fix

### DIFF
--- a/script.js
+++ b/script.js
@@ -213,7 +213,9 @@ var sorttable = {
             {
                 colOptions = overrides[i + 1];
             }
-            if ( !colOptions.match( /\bnosort\b/ ) ) { // skip this col
+            if ( colOptions.match( /\bnosort\b/ ) ) {
+                jQuery(headrow[i]).addClass("sorttable_nosort");
+            } else { // skip this col
                 var mtch = colOptions.match( /\b[a-z0-9]+\b/ );
                 var override;
                 if ( mtch ) {


### PR DESCRIPTION
Because there's already CSS to exclude class `sorttable_nosort`, the .js just needs to add that class to `nosort` columns.  This fix is simpler than [Remove arrows for "nosort" columns](https://github.com/FyiurAmron/sortablejs/pull/30) by @tcheradeev