### PR TITLE
Remove deprecated use of require_once(syntax.php)

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base sortablejs
 author vaxquis
 email spamove@gmail.com
-date 2023-04-12
+date 2023-04-20
 name sortablejs
 desc Allow sorting tables by columns
 url https://github.com/FyiurAmron/sortablejs

--- a/syntax.php
+++ b/syntax.php
@@ -12,9 +12,6 @@
 // must be run within Dokuwiki
 if ( !defined( 'DOKU_INC' ) )
     die();
-if ( !defined( 'DOKU_PLUGIN' ) )
-    define( 'DOKU_PLUGIN', DOKU_INC.'lib/plugins/' );
-require_once(DOKU_PLUGIN.'syntax.php');
 //
 class syntax_plugin_sortablejs extends DokuWiki_Syntax_Plugin {
 


### PR DESCRIPTION
From the DokuWiki deprecation log:
require(syntax.php) is deprecated. It was called from require() in .../sortablejs/syntax.php:17 Autoloading should be used instead!

PHP 8.2, DokuWiki Jack Jackrum, sortablejs 2023-04-12